### PR TITLE
Add ir:rst access for CIA/3DS builds.

### DIFF
--- a/3DS/cxi/build_cia.rsf
+++ b/3DS/cxi/build_cia.rsf
@@ -196,7 +196,7 @@ AccessControlInfo:
    - y2r:u
    - ldr:ro
    - ir:USER
-  
+   - ir:rst
    
 SystemControlInfo:
   SaveDataSize: 0KB # It doesn't use any save data.

--- a/3DS/cxi/gw_workaround.rsf
+++ b/3DS/cxi/gw_workaround.rsf
@@ -161,6 +161,7 @@ AccessControlInfo:
    - y2r:u
    - ldr:ro
    - ir:USER
+   - ir:rst
   
    
 SystemControlInfo:


### PR DESCRIPTION
Required for CIA/3DS builds to access ZL/ZR/C-stick.